### PR TITLE
Add devcontainer configuration for ZavaStorefront

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+{
+  "name": "ZavaStorefront Codespace",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:1-6.0-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/azure-cli:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "dotnet dev-certs https --trust && cd src && dotnet restore && az bicep install && (command -v azd >/dev/null 2>&1 || curl -fsSL https://aka.ms/install-azd.sh | bash) && az version && azd version",
+  "containerEnv": {
+    "ASPNETCORE_URLS": "http://0.0.0.0:5256;https://0.0.0.0:7060"
+  },
+  "forwardPorts": [5256, 7060],
+  "portsAttributes": {
+    "5256": {
+      "label": "ASP.NET Core (HTTP)",
+      "onAutoForward": "notify",
+      "protocol": "http"
+    },
+    "7060": {
+      "label": "ASP.NET Core (HTTPS)",
+      "onAutoForward": "notify",
+      "protocol": "https"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "dotnet.defaultSolution": "src/ZavaStorefront.sln",
+        "editor.formatOnSave": true,
+        "files.autoSave": "onFocusChange"
+      },
+      "extensions": [
+        "ms-dotnettools.csharp",
+        "ms-azuretools.vscode-bicep",
+        "ms-azuretools.azure-dev",
+        "ms-azuretools.vscode-azureappservice"
+      ]
+    }
+  },
+  "remoteUser": "vscode"
+}


### PR DESCRIPTION
**Add Dev Container Support for Azure-Ready Codespaces**

- 🚀 **Motivation**  
  Codespaces sessions currently need manual setup for .NET tooling, Azure CLI, and HTTPS dev certificates, which slows contributors and risks configuration drift.

- 🛠️ **Proposed approach**  
  - Ship a `devcontainer.json` (plus supporting Dockerfile/scripts) that preloads .NET 6 SDK, Azure CLI, GitHub CLI, and optional azd/Bicep tooling.  
  - Configure `postCreateCommand` / `postStartCommand` to trust HTTPS dev certs, run `dotnet restore`, and log az/azd version checks.  
  - Expose the ASP.NET Core app on `0.0.0.0` with ports 5256/7060 auto-forwarded for remote debugging.

- ✅ **Definition of done**  
  - A fresh Codespace can run and debug the web app with zero manual setup.  
  - Tool versions appear in startup output for quick audit.  
  - `README.md` (or dedicated doc) includes a “Launch in Codespaces” snippet outlining the workflow.

- 🤔 **Open questions**  
  - Should azd/Bicep be preinstalled by default or gated behind a feature flag?  
  - Are there enterprise-specific certificate trust requirements we need to script?

```json
{
  "name": "ZavaStorefront Codespace",
  "image": "mcr.microsoft.com/devcontainers/dotnet:1-6.0-bookworm",
  "features": {
    "ghcr.io/devcontainers/features/azure-cli:1": {},
    "ghcr.io/devcontainers/features/github-cli:1": {}
  },
  "postCreateCommand": "dotnet dev-certs https --trust && cd src && dotnet restore && az bicep install && (command -v azd >/dev/null 2>&1 || curl -fsSL https://aka.ms/install-azd.sh | bash) && az version && azd version",
  "containerEnv": {
    "ASPNETCORE_URLS": "http://0.0.0.0:5256;https://0.0.0.0:7060"
  },
  "forwardPorts": [5256, 7060],
  "portsAttributes": {
    "5256": {
      "label": "ASP.NET Core (HTTP)",
      "onAutoForward": "notify",
      "protocol": "http"
    },
    "7060": {
      "label": "ASP.NET Core (HTTPS)",
      "onAutoForward": "notify",
      "protocol": "https"
    }
  },
  "customizations": {
    "vscode": {
      "settings": {
        "dotnet.defaultSolution": "src/ZavaStorefront.sln",
        "editor.formatOnSave": true,
        "files.autoSave": "onFocusChange"
      },
      "extensions": [
        "ms-dotnettools.csharp",
        "ms-azuretools.vscode-bicep",
        "ms-azuretools.azure-dev",
        "ms-azuretools.vscode-azureappservice"
      ]
    }
  },
  "remoteUser": "vscode"
}
```
